### PR TITLE
fix: add support Jira API Cloud version

### DIFF
--- a/metaissue.go
+++ b/metaissue.go
@@ -135,7 +135,7 @@ func (s *IssueService) isJiraAPI9(ctx context.Context) bool {
 
 	// versionNumbers contains an array with 3 numbers: major, minor, patch.
 	// we need only a major number
-	if version.VersionNumbers[0] == 9 {
+	if version.VersionNumbers[0] >= 9 {
 		return true
 	}
 	return false

--- a/metaissue.go
+++ b/metaissue.go
@@ -143,7 +143,7 @@ func (s *IssueService) GetJiraAPIVersion(ctx context.Context) int {
 
 // GetCreateMetaWithOptionsWithContext makes the api call to get the meta information without requiring to have a projectKey
 func (s *IssueService) GetCreateMetaWithOptionsWithContext(ctx context.Context, options *GetQueryOptions) (*CreateMetaInfo, *Response, error) {
-	if jiraV := s.GetJiraAPIVersion(ctx); jiraV > JIRA_API_9 && jiraV != JIRA_API_CLOUD {
+	if jiraV := s.GetJiraAPIVersion(ctx); jiraV >= JIRA_API_9 && jiraV != JIRA_API_CLOUD {
 		return s.GetCreateMetaWithOptionsWithContextForJira9(ctx, options)
 	}
 	apiEndpoint := "rest/api/2/issue/createmeta/"

--- a/metaissue.go
+++ b/metaissue.go
@@ -10,7 +10,6 @@ import (
 )
 
 const (
-	JIRA_API_8     = 8
 	JIRA_API_9     = 9
 	JIRA_API_CLOUD = 1001
 )


### PR DESCRIPTION
# Description

This pull request addresses a particular issue encountered when using the Jira Cloud API's serverInfo endpoint. Currently, in certain cases, the serverInfo response contains a version that appears to be peculiar or unconventional. As a result, this pull request proposes an important fix to prevent the usage of API 9 for Jira Cloud.

**upd**: 
the next `if` statement looks a bit flaky:
https://github.com/aquasecurity/go-jira/blob/358abd58fd26585814d9887f41ba3fd53aa73956/metaissue.go#L134

so I refactored it.

# Checklist

* [ ] Unit or Integration tests added
  * [ ] Good Path
  * [ ] Error Path
* [ ] Commits follow conventions described here:
  * [ ] [Conventional Commits 1.0.0](https://conventionalcommits.org/en/v1.0.0-beta.4/#summary)
  * [ ] [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/#seven-rules)
* [ ] Commits are squashed such that
  * [ ] There is 1 commit per isolated change
* [ ] I've not made extraneous commits/changes that are unrelated to my change.
