### PR TITLE
chore: fix broken tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test and lint
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test and lint
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.19.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     name: Test and lint
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.18.x, 1.19.x]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ fmt: ## Runs go fmt (to check for go coding guidelines).
 
 .PHONY: staticcheck
 staticcheck: ## Runs static analysis to prevend bugs, foster code simplicity, performance and editor integration.
-	go get -u honnef.co/go/tools/cmd/staticcheck
+	go install honnef.co/go/tools/cmd/staticcheck
 	staticcheck ./...
 
 .PHONY: all

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ fmt: ## Runs go fmt (to check for go coding guidelines).
 
 .PHONY: staticcheck
 staticcheck: ## Runs static analysis to prevend bugs, foster code simplicity, performance and editor integration.
-	go install honnef.co/go/tools/cmd/staticcheck
+	go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
 	staticcheck ./...
 
 .PHONY: all

--- a/issue.go
+++ b/issue.go
@@ -596,7 +596,7 @@ type RemoteLinkStatus struct {
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
-// The given options will be appended to the query string
+// # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira/REST/latest/#api/2/issue-getIssue
 func (s *IssueService) GetWithContext(ctx context.Context, issueID string, options *GetQueryOptions) (*Issue, *Response, error) {
@@ -1264,15 +1264,17 @@ func (s *IssueService) DoTransitionWithPayload(ticketID, payload interface{}) (*
 }
 
 // InitIssueWithMetaAndFields returns Issue with with values from fieldsConfig properly set.
-//  * metaProject should contain metaInformation about the project where the issue should be created.
-//  * metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
-//  * fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
-//		And value is the string value for that particular key.
+//   - metaProject should contain metaInformation about the project where the issue should be created.
+//   - metaIssuetype is the MetaInformation about the Issuetype that needs to be created.
+//   - fieldsConfig is a key->value pair where key represents the name of the field as seen in the UI
+//     And value is the string value for that particular key.
+//
 // Note: This method doesn't verify that the fieldsConfig is complete with mandatory fields. The fieldsConfig is
-//		 supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
-//		 error if the key is not found.
-//		 All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
-//		 configured as well, marshalling and unmarshalling will set the proper fields.
+//
+//	supposed to be already verified with MetaIssueType.CheckCompleteAndAvailable. It will however return
+//	error if the key is not found.
+//	All values will be packed into Unknowns. This is much convenient. If the struct fields needs to be
+//	configured as well, marshalling and unmarshalling will set the proper fields.
 func InitIssueWithMetaAndFields(metaProject *MetaProject, metaIssuetype *MetaIssueType, fieldsConfig map[string]string) (*Issue, error) {
 	issue := new(Issue)
 	issueFields := new(IssueFields)

--- a/jira.go
+++ b/jira.go
@@ -517,8 +517,9 @@ func (t *CookieAuthTransport) transport() http.RoundTripper {
 //
 // Jira docs: https://developer.atlassian.com/cloud/jira/platform/understanding-jwt
 // Examples in other languages:
-//    https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
-//    https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
+//
+//	https://bitbucket.org/atlassian/atlassian-jwt-ruby/src/d44a8e7a4649e4f23edaa784402655fda7c816ea/lib/atlassian/jwt.rb
+//	https://bitbucket.org/atlassian/atlassian-jwt-py/src/master/atlassian_jwt/url_utils.py
 type JWTAuthTransport struct {
 	Secret []byte
 	Issuer string

--- a/metaissue.go
+++ b/metaissue.go
@@ -219,19 +219,21 @@ func (p *MetaProject) GetIssueTypeWithName(name string) *MetaIssueType {
 
 // GetMandatoryFields returns a map of all the required fields from the MetaIssueTypes.
 // if a field returned by the api was:
-// "customfield_10806": {
-//					"required": true,
-//					"schema": {
-//						"type": "any",
-//						"custom": "com.pyxis.greenhopper.jira:gh-epic-link",
-//						"customId": 10806
-//					},
-//					"name": "Epic Link",
-//					"hasDefaultValue": false,
-//					"operations": [
-//						"set"
-//					]
-//				}
+//
+//	"customfield_10806": {
+//						"required": true,
+//						"schema": {
+//							"type": "any",
+//							"custom": "com.pyxis.greenhopper.jira:gh-epic-link",
+//							"customId": 10806
+//						},
+//						"name": "Epic Link",
+//						"hasDefaultValue": false,
+//						"operations": [
+//							"set"
+//						]
+//					}
+//
 // the returned map would have "Epic Link" as the key and "customfield_10806" as value.
 // This choice has been made so that the it is easier to generate the create api request later.
 func (t *MetaIssueType) GetMandatoryFields() (map[string]string, error) {

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -11,14 +11,14 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
 	setup()
 	defer teardown()
 
-	testVersionEndpoint := "rest/api/2/serverInfo"
+	testVersionEndpoint := "/rest/api/2/serverInfo"
 	testMux.HandleFunc(testVersionEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, testVersionEndpoint)
-		fmt.Fprint(w, `{"baseUrl":"http://localhost:8088","version":"8.13.0","versionNumbers":[8,13,0],"deploymentType":"Server","buildNumber":813000,"buildDate":"2020-10-07T00:00:00.000+0000","databaseBuildNumber":813000,"serverTime":"2023-07-04T07:37:30.228+0000","scmInfo":"8c68d8036d917652ef7564456d59d80184b5a77e","serverTitle":"Jira"}`)
+		fmt.Fprint(w, `{"baseUrl":"https://my.jira.com","version":"8.13.0","versionNumbers":[8,13,0],"deploymentType":"Server","buildNumber":813000,"buildDate":"2020-10-07T00:00:00.000+0000","databaseBuildNumber":813000,"serverTime":"2023-07-04T07:37:30.228+0000","scmInfo":"8c68d8036d917652ef7564456d59d80184b5a77e","serverTitle":"Jira"}`)
 	})
 
-	testAPIEndpoint := "rest/api/2/issue/createmeta"
+	testAPIEndpoint := "/rest/api/2/issue/createmeta/"
 	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, testAPIEndpoint)

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -11,8 +11,14 @@ func TestIssueService_GetCreateMeta_Success(t *testing.T) {
 	setup()
 	defer teardown()
 
-	testAPIEndpoint := "/rest/api/2/issue/createmeta"
+	testVersionEndpoint := "rest/api/2/serverInfo"
+	testMux.HandleFunc(testVersionEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testVersionEndpoint)
+		fmt.Fprint(w, `{"baseUrl":"http://localhost:8088","version":"8.13.0","versionNumbers":[8,13,0],"deploymentType":"Server","buildNumber":813000,"buildDate":"2020-10-07T00:00:00.000+0000","databaseBuildNumber":813000,"serverTime":"2023-07-04T07:37:30.228+0000","scmInfo":"8c68d8036d917652ef7564456d59d80184b5a77e","serverTitle":"Jira"}`)
+	})
 
+	testAPIEndpoint := "rest/api/2/issue/createmeta"
 	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, testAPIEndpoint)

--- a/metaissue_test.go
+++ b/metaissue_test.go
@@ -466,8 +466,14 @@ func TestMetaIssueType_GetCreateMetaWithOptions(t *testing.T) {
 	setup()
 	defer teardown()
 
-	testAPIEndpoint := "/rest/api/2/issue/createmeta"
+	testVersionEndpoint := "/rest/api/2/serverInfo"
+	testMux.HandleFunc(testVersionEndpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testRequestURL(t, r, testVersionEndpoint)
+		fmt.Fprint(w, `{"baseUrl":"https://my.jira.com","version":"8.13.0","versionNumbers":[8,13,0],"deploymentType":"Server","buildNumber":813000,"buildDate":"2020-10-07T00:00:00.000+0000","databaseBuildNumber":813000,"serverTime":"2023-07-04T07:37:30.228+0000","scmInfo":"8c68d8036d917652ef7564456d59d80184b5a77e","serverTitle":"Jira"}`)
+	})
 
+	testAPIEndpoint := "/rest/api/2/issue/createmeta/"
 	testMux.HandleFunc(testAPIEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testRequestURL(t, r, testAPIEndpoint)

--- a/sprint.go
+++ b/sprint.go
@@ -84,7 +84,7 @@ func (s *SprintService) GetIssuesForSprint(sprintID int) ([]Issue, *Response, er
 // This can be an issue id, or an issue key.
 // If the issue cannot be found via an exact match, Jira will also look for the issue in a case-insensitive way, or by looking to see if the issue was moved.
 //
-// The given options will be appended to the query string
+// # The given options will be appended to the query string
 //
 // Jira API docs: https://docs.atlassian.com/jira-software/REST/7.3.1/#agile/1.0/issue-getIssue
 //


### PR DESCRIPTION
# Description
We encountered several issues that caused our tests to break. 
Here's a breakdown of the problems we identified:

* Outdated Go version: The tests were built using an older version of Go, which led to compatibility issues with `staticcheck`. 
* Incorrect Go formatting for Go 1.19: The formatting of the code didn't adhere to the standards of Go 1.19, resulting in test failures.
* #17 uses a new Jira API `serverInfo`: To accommodate the new API, we had to introduce a new mock endpoint.

We have addressed these issues to ensure the stability and functionality of our tests.
